### PR TITLE
Fixed --basePath argument being ignored.

### DIFF
--- a/src/csmacnz.Coveralls/PathStripper.cs
+++ b/src/csmacnz.Coveralls/PathStripper.cs
@@ -8,7 +8,7 @@ namespace csmacnz.Coveralls
 
         public PathProcessor(string basePath)
         {
-            _basePath = !string.IsNullOrWhiteSpace(_basePath) ? basePath : Directory.GetCurrentDirectory();
+            _basePath = !string.IsNullOrWhiteSpace(basePath) ? basePath : Directory.GetCurrentDirectory();
         }
 
         public string ConvertPath(string path)


### PR DESCRIPTION
The value of the ```--basePath``` argument is never used because the private member field is checked for not being null instead of the constructor argument for ```PathProcessor```. Because of this the specified value is always thought to be null and is consequently never used.