### PR TITLE
Use COVERALLS_REPO_TOKEN Environment Variable

### DIFF
--- a/build.tasks.ps1
+++ b/build.tasks.ps1
@@ -120,7 +120,7 @@ task coverage-only {
     exec { & .\src\packages\OpenCover.4.5.3723\OpenCover.Console.exe -register:user -target:$script:xunit "-targetargs:""src\csmacnz.Coveralls.Tests\bin\$Configuration\csmacnz.Coveralls.Tests.dll"" -noshadow $script:testOptions" -filter:"+[csmacnz.Coveralls*]*" -output:opencovertests.xml }
 }
 
-task coveralls -depends coverage, coveralls-only
+task coveralls -precondition { return $env:COVERALLS_REPO_TOKEN -ne "" } -depends coverage, coveralls-only
 
 task coveralls-only {
     exec { & ".\src\csmacnz.Coveralls\bin\$configuration\csmacnz.Coveralls.exe" --opencover -i opencovertests.xml --repoToken $env:COVERALLS_REPO_TOKEN }

--- a/build.tasks.ps1
+++ b/build.tasks.ps1
@@ -120,9 +120,9 @@ task coverage-only {
     exec { & .\src\packages\OpenCover.4.5.3723\OpenCover.Console.exe -register:user -target:$script:xunit "-targetargs:""src\csmacnz.Coveralls.Tests\bin\$Configuration\csmacnz.Coveralls.Tests.dll"" -noshadow $script:testOptions" -filter:"+[csmacnz.Coveralls*]*" -output:opencovertests.xml }
 }
 
-task coveralls -precondition { return $env:COVERALLS_REPO_TOKEN -ne "" } -depends coverage, coveralls-only
+task coveralls -depends coverage, coveralls-only
 
-task coveralls-only {
+task coveralls-only -precondition { return $env:COVERALLS_REPO_TOKEN -ne $null } {
     exec { & ".\src\csmacnz.Coveralls\bin\$configuration\csmacnz.Coveralls.exe" --opencover -i opencovertests.xml --repoToken $env:COVERALLS_REPO_TOKEN }
 }
 

--- a/src/csmacnz.Coveralls/Main.usage.txt
+++ b/src/csmacnz.Coveralls/Main.usage.txt
@@ -1,7 +1,7 @@
 ﻿csmac.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
-  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml --repoToken <repoToken> [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>]
+  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml [--repoToken <repoToken>] [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>]
   csmacnz.Coveralls --version
   csmacnz.Coveralls --help
 

--- a/src/csmacnz.Coveralls/Program.cs
+++ b/src/csmacnz.Coveralls/Program.cs
@@ -15,7 +15,8 @@ namespace csmacnz.Coveralls
         public static void Main(string[] argv)
         {
             var args = new MainArgs(argv, exit: true, version: Assembly.GetEntryAssembly().GetName().Version);
-            var repoToken = args.OptRepotoken;
+            var repoToken = ResolveCoveralsRepoToken(args);
+
             if (string.IsNullOrWhiteSpace(repoToken))
             {
                 Console.Error.WriteLine("parameter repoToken is required.");
@@ -136,6 +137,14 @@ namespace csmacnz.Coveralls
             var jobId = new EnvironmentVariables().GetEnvironmentVariable("APPVEYOR_JOB_ID");
             if (jobId.IsNotNullOrWhitespace()) return jobId;
             return "0";
+        }
+
+        private static string ResolveCoveralsRepoToken(MainArgs args)
+        {
+            if (args.IsProvided("--repoToken")) return args.OptRepotoken;
+            var repoToken = new EnvironmentVariables().GetEnvironmentVariable("COVERALLS_REPO_TOKEN");
+            if (repoToken.IsNotNullOrWhitespace()) return repoToken;
+            return null;
         }
 
         private static GitData ResolveGitData(MainArgs args)

--- a/src/csmacnz.Coveralls/T4DocoptNet.cs
+++ b/src/csmacnz.Coveralls/T4DocoptNet.cs
@@ -1,15 +1,37 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 using System.Collections.Generic;
 using DocoptNet;
 
 namespace csmacnz.Coveralls
 {
+
     // Generated class for Main.usage.txt
     public class MainArgs
     {
         public const string Usage = @"csmac.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
-  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml --repoToken <repoToken> [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>]
+  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml [--repoToken <repoToken>] [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>]
   csmacnz.Coveralls --version
   csmacnz.Coveralls --help
 
@@ -30,8 +52,8 @@ Options:
  --commitAuthor <commitAuthor>   The git commit author for the coverage report.
  --commitEmail <commitEmail>     The git commit author email for the coverage report.
  --commitMessage <commitMessage> The git commit message for the coverage report.
- --jobId <jobId>                 The job Id to provide to coveralls.io.
- --serviceName <Name>            The service-name for the coverage report. [default: ""coveralls.net""]
+ --jobId <jobId>                 The job Id to provide to coveralls.io. [default: 0]
+ --serviceName <Name>            The service-name for the coverage report. [default: coveralls.net]
 
 Commit Options:
   If --commitId and --commitBranch are provided, all git settings will come from the command line arguments.
@@ -66,7 +88,7 @@ What its for:
             return _args[parameter] != null;
         }
 
-		public bool OptOpencover { get { return _args["--opencover"].IsTrue; } }
+public bool OptOpencover { get { return _args["--opencover"].IsTrue; } }
 		public bool OptDynamiccodecoverage { get { return _args["--dynamiccodecoverage"].IsTrue; } }
 		public bool OptMonocov { get { return _args["--monocov"].IsTrue; } }
 		public string OptInput { get { return _args["--input"].ToString(); } }


### PR DESCRIPTION
I use the application in AppVeyor and once there was a transient network issue that caused the upload to coveralls.io to fail. That meant that MSBuild dumped the command that was passed to the Exec task to the build log and [leaked my secure repo token on line 512](https://ci.appveyor.com/project/martincostello/sqllocaldb/build/1.15.114.0). I then had to regenerate the token so the leaked value was no longer valid.

This PR makes ```--repoToken``` optional by allowing the value to come from the ```COVERALLS_REPO_TOKEN``` environment variable if the value is not explicitly set on the command line. I chose this name as it's the value you use in your own builds.

The strange indenting seems to be caused by something in the T4 template, but I've left that alone as it's unrelated to the PR.