### PR TITLE
Pull request support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.vs/
 
 # Build results
 [Dd]ebug/
@@ -128,7 +129,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj

--- a/.gitignore
+++ b/.gitignore
@@ -188,13 +188,11 @@ FakesAssemblies/
 
 Package/
 
+#Build Artifacts
 cov-int/
 coveralls.coverity.*.zip
-
+coveralls.net.*.zip
+coveralls.net.*.nupkg
 opencovertests.xml
-
-resharperReport.xml
-resharperReport.html
-
-duplicateReport.xml
-duplicateReport.html
+*Report.xml
+*Report.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: csharp
 solution: ./src/csmacnz.Coveralls.sln
+sudo: false
 install:
   - export MONO_INTEGRATION_MODE=True
   - nuget restore ./src/csmacnz.Coveralls.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ install:
   - nuget restore ./src/csmacnz.Coveralls.sln
 script:
   - xbuild /p:Configuration=Release ./src/csmacnz.Coveralls.sln
+cache:
+  directories:
+  - ./src/packages

--- a/Build.environment.ps1
+++ b/Build.environment.ps1
@@ -1,18 +1,3 @@
 choco install -y psake
-choco install -y pscx
 choco install -y nuget.CommandLine
 choco install -y GitVersion.Portable
-
-$pscxPath = "C:\Program Files (x86)\PowerShell Community Extensions\Pscx3\Pscx";
-
-if (-not (Test-Path $pscxPath))
-{
-    $pscxPath = $null;
-    Write-Host "Searching for the pscx powershell module.";
-    $pscxPath = (Get-ChildItem -Path "C:\Program Files\" -Filter "pscx.dll" -Recurse).FullName;
-    if (!$pscxPath) { $pscxPath = (Get-ChildItem -Path "C:\Program Files (x86)\" -Filter "pscx.dll" -Recurse).FullName; }
-    $pscxPath = Split-Path $pscxPath;
-    Write-Host "Found it at " + $pscxPath;
-}
-
-$env:PSModulePath = $env:PSModulePath + ";" + $pscxPath;

--- a/BuildTools/dupfinder.xslt
+++ b/BuildTools/dupfinder.xslt
@@ -7,7 +7,7 @@
                 <h1>Statistics</h1>
                 <p>Total codebase size: <xsl:value-of select="//CodebaseCost"/></p>
                 <p>Code to analyze: <xsl:value-of select="//TotalDuplicatesCost"/></p>
-                <p>Total size of duplicated fragments: <xsl:value-of select="//CodebaseCost" /></p>
+                <p>Total size of duplicated fragments: <xsl:value-of select="//TotalFragmentsCost" /></p>
                 <h1>Detected Duplicates</h1>
                 <xsl:for-each select="//Duplicates/Duplicate">
                     <h2>Duplicated Code. Size: <xsl:value-of  select="@Cost"/></h2>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ environment:
     secure: eJdOjCT+V5sq+EWTsuBwx8r47EHFutwOxnA2+yhdA2E=
   COVERITY_EMAIL:
     secure: YNNLrvdTPJBtXcWskGnutoOOXbWeulhguf0c7iX9Gis=
+cache:
+- src\packages -> **\packages.config
+- C:\ProgramData\chocolatey\bin -> build.environment.ps1
+- C:\ProgramData\chocolatey\lib -> build.environment.ps1
 install:
 - ps: .\build.environment.ps1
 - ps: psake .\build.tasks.ps1 appveyor-install

--- a/build.tasks.ps1
+++ b/build.tasks.ps1
@@ -186,7 +186,7 @@ task dupfinder {
 
 task inspect {
     $inspectcode = (Resolve-Path ".\src\packages\JetBrains.ReSharper.CommandLineTools.*\tools\inspectcode.exe").ToString()
-    & $inspectcode /o="resharperReport.xml" ".\src\csmacnz.Coveralls.sln" 2> $null
+    & $inspectcode /o="resharperReport.xml" ".\src\csmacnz.Coveralls.sln"
     [xml]$stats = Get-Content .\resharperReport.xml
     $anyErrors = $FALSE;
     $errors = $stats.SelectNodes("/Report/IssueTypes/IssueType")

--- a/build.tasks.ps1
+++ b/build.tasks.ps1
@@ -152,7 +152,7 @@ task coveralls-only -precondition { return -not $env:APPVEYOR_PULL_REQUEST_NUMBE
 
 task dupfinder {
     $dupfinder = (Resolve-Path ".\src\packages\JetBrains.ReSharper.CommandLineTools.*\tools\dupfinder.exe").ToString()
-    & $dupfinder /o="duplicateReport.xml" /show-text ".\src\csmacnz.Coveralls.sln" 2> $null
+    & $dupfinder /o="duplicateReport.xml" /show-text ".\src\csmacnz.Coveralls.sln" 2>&1
     [xml]$stats = Get-Content .\duplicateReport.xml
     $anyDuplicates = $FALSE;
 
@@ -186,7 +186,7 @@ task dupfinder {
 
 task inspect {
     $inspectcode = (Resolve-Path ".\src\packages\JetBrains.ReSharper.CommandLineTools.*\tools\inspectcode.exe").ToString()
-    & $inspectcode /o="resharperReport.xml" ".\src\csmacnz.Coveralls.sln" 2> $null
+    & $inspectcode /o="resharperReport.xml" ".\src\csmacnz.Coveralls.sln" 2>&1
     [xml]$stats = Get-Content .\resharperReport.xml
     $anyErrors = $FALSE;
     $errors = $stats.SelectNodes("/Report/IssueTypes/IssueType")

--- a/build.tasks.ps1
+++ b/build.tasks.ps1
@@ -152,7 +152,7 @@ task coveralls-only -precondition { return -not $env:APPVEYOR_PULL_REQUEST_NUMBE
 
 task dupfinder {
     $dupfinder = (Resolve-Path ".\src\packages\JetBrains.ReSharper.CommandLineTools.*\tools\dupfinder.exe").ToString()
-    & $dupfinder /o="duplicateReport.xml" /show-text ".\src\csmacnz.Coveralls.sln" 2>&1
+    exec { & $dupfinder /o="duplicateReport.xml" /show-text $sln_file } -errorAction SilentlyContinue
     [xml]$stats = Get-Content .\duplicateReport.xml
     $anyDuplicates = $FALSE;
 
@@ -186,7 +186,7 @@ task dupfinder {
 
 task inspect {
     $inspectcode = (Resolve-Path ".\src\packages\JetBrains.ReSharper.CommandLineTools.*\tools\inspectcode.exe").ToString()
-    & $inspectcode /o="resharperReport.xml" ".\src\csmacnz.Coveralls.sln" 2>&1
+    exec { & $inspectcode /o="resharperReport.xml" $sln_file } -errorAction SilentlyContinue
     [xml]$stats = Get-Content .\resharperReport.xml
     $anyErrors = $FALSE;
     $errors = $stats.SelectNodes("/Report/IssueTypes/IssueType")

--- a/build.tasks.ps1
+++ b/build.tasks.ps1
@@ -152,7 +152,7 @@ task coveralls-only -precondition { return -not $env:APPVEYOR_PULL_REQUEST_NUMBE
 
 task dupfinder {
     $dupfinder = (Resolve-Path ".\src\packages\JetBrains.ReSharper.CommandLineTools.*\tools\dupfinder.exe").ToString()
-    exec { & $dupfinder /o="duplicateReport.xml" /show-text $sln_file } -errorAction SilentlyContinue
+    exec { cmd /c $dupfinder /o="duplicateReport.xml" /show-text $sln_file 2`> nul }
     [xml]$stats = Get-Content .\duplicateReport.xml
     $anyDuplicates = $FALSE;
 
@@ -186,7 +186,7 @@ task dupfinder {
 
 task inspect {
     $inspectcode = (Resolve-Path ".\src\packages\JetBrains.ReSharper.CommandLineTools.*\tools\inspectcode.exe").ToString()
-    exec { & $inspectcode /o="resharperReport.xml" $sln_file } -errorAction SilentlyContinue
+    exec { cmd /c $inspectcode /o="resharperReport.xml" $sln_file 2`> nul }
     [xml]$stats = Get-Content .\resharperReport.xml
     $anyErrors = $FALSE;
     $errors = $stats.SelectNodes("/Report/IssueTypes/IssueType")

--- a/build.tasks.ps1
+++ b/build.tasks.ps1
@@ -247,21 +247,10 @@ task pack -depends build, pack-only
 
 task pack-only -depends SetChocolateyPath {
 
-    mkdir $nuget_pack_dir
-    cp "$nuspec_filename" "$nuget_pack_dir"
-
-    $nuget_tools_dir = "$nuget_pack_dir\tools"
-    mkdir $nuget_tools_dir
-    cp "$build_output_dir\*.*" "$nuget_tools_dir"
-
-    $Spec = [xml](get-content "$nuget_pack_dir\$nuspec_filename")
-    $Spec.package.metadata.version = ([string]$Spec.package.metadata.version).Replace("{Version}", $script:nugetVersion)
-    $Spec.Save("$nuget_pack_dir\$nuspec_filename")
-
     $chocolateyBinDir = Join-Path $script:chocolateyDir -ChildPath "bin";
     $NuGetExe = Join-Path $chocolateyBinDir -ChildPath "NuGet.exe";
 
-    exec { & $NuGetExe pack "$nuget_pack_dir\$nuspec_filename" }
+    exec { & $NuGetExe pack .\src\csmacnz.Coveralls\csmacnz.Coveralls.nuspec -Version $script:nugetVersion -Properties Configuration=Release }
 }
 
 task postbuild -depends coverage-only, integration, mono-integration, coveralls-only, inspect, dupfinder, archive-only, pack-only

--- a/build.tasks.ps1
+++ b/build.tasks.ps1
@@ -186,7 +186,7 @@ task dupfinder {
 
 task inspect {
     $inspectcode = (Resolve-Path ".\src\packages\JetBrains.ReSharper.CommandLineTools.*\tools\inspectcode.exe").ToString()
-    & $inspectcode /o="resharperReport.xml" ".\src\csmacnz.Coveralls.sln"
+    & $inspectcode /o="resharperReport.xml" ".\src\csmacnz.Coveralls.sln" 2> $null
     [xml]$stats = Get-Content .\resharperReport.xml
     $anyErrors = $FALSE;
     $errors = $stats.SelectNodes("/Report/IssueTypes/IssueType")

--- a/build.tasks.ps1
+++ b/build.tasks.ps1
@@ -240,7 +240,9 @@ task archive-only {
 
     cp "$build_output_dir\*.*" "$archive_dir"
 
-    Write-Zip -Path "$archive_dir\*" -OutputPath $archive_filename
+    Add-Type -assembly "system.io.compression.filesystem"
+
+    [io.compression.zipfile]::CreateFromDirectory("$archive_dir", $archive_filename)
 }
 
 task pack -depends build, pack-only

--- a/src/csmacnz.Coveralls.Tests.Integration/UsageTests.cs
+++ b/src/csmacnz.Coveralls.Tests.Integration/UsageTests.cs
@@ -33,7 +33,7 @@ namespace csmacnz.Coveralls.Tests.Integration
         {
             var results = CoverallsTestRunner.RunCoveralls("--version");
 
-            Assert.True(Regex.IsMatch(results.StandardOutput, @"\d+.\d+.\d+.\d+"));
+            Assert.True(Regex.IsMatch(results.StandardOutput, @"\d+.\d+.\d+.\d+"), "Version doesn't match regex: " + results.StandardOutput);
         }
 
         [Fact]

--- a/src/csmacnz.Coveralls.Tests.Integration/UsageTests.cs
+++ b/src/csmacnz.Coveralls.Tests.Integration/UsageTests.cs
@@ -60,7 +60,7 @@ namespace csmacnz.Coveralls.Tests.Integration
             Assert.Contains("csmacnz.Coveralls --help", results.StandardOutput);
             Assert.Contains("Options:", results.StandardOutput);
             Assert.Contains("Options:", results.StandardOutput);
-            Assert.Contains("What its for:", results.StandardOutput);
+            Assert.Contains("What it's for:", results.StandardOutput);
         }
     }
 }

--- a/src/csmacnz.Coveralls.sln
+++ b/src/csmacnz.Coveralls.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\appveyor.yml = ..\appveyor.yml
 		..\Build.environment.ps1 = ..\Build.environment.ps1
 		..\build.tasks.ps1 = ..\build.tasks.ps1
+		..\GitVersionConfig.yaml = ..\GitVersionConfig.yaml
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/csmacnz.Coveralls.sln
+++ b/src/csmacnz.Coveralls.sln
@@ -12,7 +12,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\appveyor.yml = ..\appveyor.yml
 		..\Build.environment.ps1 = ..\Build.environment.ps1
 		..\build.tasks.ps1 = ..\build.tasks.ps1
-		..\coveralls.net.nuspec = ..\coveralls.net.nuspec
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/csmacnz.Coveralls/CoverallData.cs
+++ b/src/csmacnz.Coveralls/CoverallData.cs
@@ -13,6 +13,9 @@ namespace csmacnz.Coveralls
         [JsonProperty("service_name")]
         public string ServiceName { get; set; }
 
+        [JsonProperty("service_pull_request", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string PullRequestId { get; set; }
+
         [JsonProperty("source_files")]
         public CoverageFile[] SourceFiles { get; set; }
 

--- a/src/csmacnz.Coveralls/Main.usage.txt
+++ b/src/csmacnz.Coveralls/Main.usage.txt
@@ -1,7 +1,7 @@
 ﻿csmacnz.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
-  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]
+  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--pullRequest <pullRequestId>] [--treatUploadErrorsAsWarnings]
   csmacnz.Coveralls --version
   csmacnz.Coveralls --help
 
@@ -25,6 +25,7 @@ Options:
  --commitMessage <commitMessage>          The git commit message for the coverage report.
  --jobId <jobId>                          The job Id to provide to coveralls.io. [default: 0]
  --serviceName <Name>                     The service-name for the coverage report. [default: coveralls.net]
+ --pullRequest <pullRequestId>            The github pull request id. Used for updating status on github PRs.
  -k, --treatUploadErrorsAsWarnings        Exit successfully if an upload error is encountered and this flag is set.
 
 Commit Options:

--- a/src/csmacnz.Coveralls/Main.usage.txt
+++ b/src/csmacnz.Coveralls/Main.usage.txt
@@ -1,4 +1,4 @@
-﻿csmac.Coveralls - a coveralls.io coverage publisher for .Net
+﻿csmacnz.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
   csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]
@@ -34,7 +34,7 @@ Commit Options:
     * If git is available in the current working directory, the settings will be loaded from git.
 
 
-What its for:
+What it's for:
  Reads your .Net code coverage output data and submits it to
  coveralls.io's service. This can be used by your build scripts
  or with a CI builder server.

--- a/src/csmacnz.Coveralls/Program.cs
+++ b/src/csmacnz.Coveralls/Program.cs
@@ -151,6 +151,10 @@ namespace csmacnz.Coveralls
                         ExitWithError(message);
                     }
                 }
+                else
+                {
+                    Console.WriteLine("Coverage data uploaded to coveralls.");
+                }
             }
         }
 

--- a/src/csmacnz.Coveralls/Program.cs
+++ b/src/csmacnz.Coveralls/Program.cs
@@ -118,6 +118,7 @@ namespace csmacnz.Coveralls
             var gitData = ResolveGitData(args);
 
             var serviceJobId = ResolveServiceJobId(args);
+            var pullRequestId = ResolvePullRequestId(args);
 
             string serviceName = args.IsProvided("--serviceName") ? args.OptServicename : "coveralls.net";
             var data = new CoverallData
@@ -125,6 +126,7 @@ namespace csmacnz.Coveralls
                 RepoToken = repoToken,
                 ServiceJobId = serviceJobId.ValueOr("0"),
                 ServiceName = serviceName,
+                PullRequestId = pullRequestId.ValueOr(null),
                 SourceFiles = files.ToArray(),
                 Git = gitData.ValueOrDefault()
             };
@@ -168,6 +170,14 @@ namespace csmacnz.Coveralls
             if (args.IsProvided("--jobId")) return args.OptJobid;
             var jobId = new EnvironmentVariables().GetEnvironmentVariable("APPVEYOR_JOB_ID");
             if (jobId.IsNotNullOrWhitespace()) return jobId;
+            return null;
+        }
+
+        private static Option<string> ResolvePullRequestId(MainArgs args)
+        {
+            if (args.IsProvided("--pullRequest")) return args.OptPullrequest;
+            var prId = new EnvironmentVariables().GetEnvironmentVariable("APPVEYOR_PULL_REQUEST_NUMBER");
+            if (prId.IsNotNullOrWhitespace()) return prId;
             return null;
         }
 

--- a/src/csmacnz.Coveralls/Properties/AssemblyInfo.cs
+++ b/src/csmacnz.Coveralls/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("csmacnz.Coveralls")]
 [assembly: AssemblyDescription("Coveralls.io uploader for .NET Code Coverage")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("csmacnz")]
+[assembly: AssemblyCompany("csMACnz")]
 [assembly: AssemblyProduct("csmacnz.Coveralls")]
 [assembly: AssemblyCopyright("Copyright © csMACnz 2015")]
 [assembly: AssemblyTrademark("")]

--- a/src/csmacnz.Coveralls/T4DocoptNet.cs
+++ b/src/csmacnz.Coveralls/T4DocoptNet.cs
@@ -6,7 +6,7 @@ namespace csmacnz.Coveralls
     // Generated class for Main.usage.txt
     public class MainArgs
     {
-        public const string Usage = @"csmac.Coveralls - a coveralls.io coverage publisher for .Net
+        public const string Usage = @"csmacnz.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
   csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]

--- a/src/csmacnz.Coveralls/T4DocoptNet.cs
+++ b/src/csmacnz.Coveralls/T4DocoptNet.cs
@@ -9,7 +9,7 @@ namespace csmacnz.Coveralls
         public const string Usage = @"csmacnz.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
-  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]
+  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--pullRequest <pullRequestId>] [--treatUploadErrorsAsWarnings]
   csmacnz.Coveralls --version
   csmacnz.Coveralls --help
 
@@ -33,6 +33,7 @@ Options:
  --commitMessage <commitMessage>          The git commit message for the coverage report.
  --jobId <jobId>                          The job Id to provide to coveralls.io. [default: 0]
  --serviceName <Name>                     The service-name for the coverage report. [default: coveralls.net]
+ --pullRequest [pullRequestId]            The github pull request id. Used for updating status on github PRs.
  -k, --treatUploadErrorsAsWarnings        Exit successfully if an upload error is encountered and this flag is set.
 
 Commit Options:
@@ -85,6 +86,7 @@ What its for:
 		public string OptCommitmessage { get { return _args["--commitMessage"].ToString(); } }
 		public string OptJobid { get { return _args["--jobId"].ToString(); } }
 		public string OptServicename { get { return _args["--serviceName"].ToString(); } }
+		public string OptPullrequest { get { return _args["--pullRequest"].ToString(); } }
 		public bool OptTreatuploaderrorsaswarnings { get { return _args["--treatUploadErrorsAsWarnings"].IsTrue; } }
 		public bool OptVersion { get { return _args["--version"].IsTrue; } }
 		public bool OptHelp { get { return _args["--help"].IsTrue; } }

--- a/src/csmacnz.Coveralls/T4DocoptNet.cs
+++ b/src/csmacnz.Coveralls/T4DocoptNet.cs
@@ -33,7 +33,7 @@ Options:
  --commitMessage <commitMessage>          The git commit message for the coverage report.
  --jobId <jobId>                          The job Id to provide to coveralls.io. [default: 0]
  --serviceName <Name>                     The service-name for the coverage report. [default: coveralls.net]
- --pullRequest [pullRequestId]            The github pull request id. Used for updating status on github PRs.
+ --pullRequest <pullRequestId>            The github pull request id. Used for updating status on github PRs.
  -k, --treatUploadErrorsAsWarnings        Exit successfully if an upload error is encountered and this flag is set.
 
 Commit Options:
@@ -43,7 +43,7 @@ Commit Options:
     * If git is available in the current working directory, the settings will be loaded from git.
 
 
-What its for:
+What it's for:
  Reads your .Net code coverage output data and submits it to
  coveralls.io's service. This can be used by your build scripts
  or with a CI builder server.";

--- a/src/csmacnz.Coveralls/csmacnz.Coveralls.csproj
+++ b/src/csmacnz.Coveralls/csmacnz.Coveralls.csproj
@@ -100,6 +100,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="csmacnz.Coveralls.nuspec" />
     <None Include="packages.config" />
     <None Include="T4DocoptNet.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
@@ -108,8 +109,8 @@
     <None Include="T4DocoptNet.tt.hooks.t4" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Properties\coverallsNet.ico" />
-    <Content Include="Main.usage.txt" />
+    <None Include="Properties\coverallsNet.ico" />
+    <None Include="Main.usage.txt" />
     <None Include="T4DocoptNet.tt.settings.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/csmacnz.Coveralls/csmacnz.Coveralls.nuspec
+++ b/src/csmacnz.Coveralls/csmacnz.Coveralls.nuspec
@@ -2,10 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>coveralls.net</id>
-    <version>{Version}</version>
+    <version>$version$</version>
     <title>coveralls.net - Coveralls.io uploader for .NET Code Coverage</title>
-    <authors>csmacnz</authors>
-    <owners>csmacnz</owners>
+    <authors>csMACnz</authors>
+    <owners>csMACnz</owners>
     <licenseUrl>https://github.com/csmacnz/coveralls.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/csmacnz/coveralls.net</projectUrl>
     <iconUrl>http://img.csmac.nz/coverallsNet-256.png</iconUrl>
@@ -14,5 +14,11 @@
       <description>Coveralls.io uploader for .NET Code Coverage. Supports opencover and visual studio's codecoverage.exe on windows, and monocov for mono</description>
     <language>en-US</language>
     <tags>Code-Coverage Coveralls opencover monocov codecoverage.exe coveralls.io Reporting Runner</tags>
+    <developmentDependency>true</developmentDependency>
   </metadata>
+  <files>
+    <file src="bin\$configuration$\*.exe" target="tools\" />
+    <file src="bin\$configuration$\*.exe.config" target="tools\" />
+    <file src="bin\$configuration$\*.dll" target="tools\" />
+  </files>
 </package>

--- a/src/csmacnz.Coveralls/csmacnz.Coveralls.nuspec
+++ b/src/csmacnz.Coveralls/csmacnz.Coveralls.nuspec
@@ -11,14 +11,15 @@
     <iconUrl>http://img.csmac.nz/coverallsNet-256.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Coveralls.io uploader for .NET Code Coverage.</summary>
-      <description>Coveralls.io uploader for .NET Code Coverage. Supports opencover and visual studio's codecoverage.exe on windows, and monocov for mono</description>
+    <description>Coveralls.io uploader for .NET Code Coverage. Supports opencover and visual studio's codecoverage.exe on windows, and monocov for mono</description>
     <language>en-US</language>
+    <copyright>Copyright 2015</copyright>
     <tags>Code-Coverage Coveralls opencover monocov codecoverage.exe coveralls.io Reporting Runner</tags>
     <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
-    <file src="bin\$configuration$\*.exe" target="tools\" />
-    <file src="bin\$configuration$\*.exe.config" target="tools\" />
+    <file src="bin\$configuration$\*.exe" target="tools\" exclude="bin\$configuration$\*.vshost.exe"/>
+    <file src="bin\$configuration$\*.exe.config" target="tools\" exclude="bin\$configuration$\*.vshost.exe.config" />
     <file src="bin\$configuration$\*.dll" target="tools\" />
   </files>
 </package>


### PR DESCRIPTION
Added support for coveralls pull request. PR number can either be specified on command line or picked up from appveyor.

Based on #39.

I have successfully set this up on a repo I'm working on. Please see https://coveralls.io/github/KentorIT/authservices for example, where the pull requests have status updates from coveralls. An example is https://github.com/KentorIT/authservices/pull/360 where the green check mark on the last commit shows coverall and appveyor statuses.

I also fixed a couple of minor typos and added a status printout on successful upload. I found it hard to know if the upload had been run or not during build without it. Please let me know if you don't like those things and I'll drop them from the PR.