### PR TITLE
Pull request support

### DIFF
--- a/src/csmacnz.Coveralls.Tests.Integration/UsageTests.cs
+++ b/src/csmacnz.Coveralls.Tests.Integration/UsageTests.cs
@@ -60,7 +60,7 @@ namespace csmacnz.Coveralls.Tests.Integration
             Assert.Contains("csmacnz.Coveralls --help", results.StandardOutput);
             Assert.Contains("Options:", results.StandardOutput);
             Assert.Contains("Options:", results.StandardOutput);
-            Assert.Contains("What its for:", results.StandardOutput);
+            Assert.Contains("What it's for:", results.StandardOutput);
         }
     }
 }

--- a/src/csmacnz.Coveralls/CoverallData.cs
+++ b/src/csmacnz.Coveralls/CoverallData.cs
@@ -13,6 +13,9 @@ namespace csmacnz.Coveralls
         [JsonProperty("service_name")]
         public string ServiceName { get; set; }
 
+        [JsonProperty("service_pull_request", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string PullRequestId { get; set; }
+
         [JsonProperty("source_files")]
         public CoverageFile[] SourceFiles { get; set; }
 

--- a/src/csmacnz.Coveralls/Main.usage.txt
+++ b/src/csmacnz.Coveralls/Main.usage.txt
@@ -1,7 +1,7 @@
 ﻿csmacnz.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
-  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]
+  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--pullRequest <pullRequestId>] [--treatUploadErrorsAsWarnings]
   csmacnz.Coveralls --version
   csmacnz.Coveralls --help
 
@@ -25,6 +25,7 @@ Options:
  --commitMessage <commitMessage>          The git commit message for the coverage report.
  --jobId <jobId>                          The job Id to provide to coveralls.io. [default: 0]
  --serviceName <Name>                     The service-name for the coverage report. [default: coveralls.net]
+ --pullRequest <pullRequestId>            The github pull request id. Used for updating status on github PRs.
  -k, --treatUploadErrorsAsWarnings        Exit successfully if an upload error is encountered and this flag is set.
 
 Commit Options:

--- a/src/csmacnz.Coveralls/Main.usage.txt
+++ b/src/csmacnz.Coveralls/Main.usage.txt
@@ -1,4 +1,4 @@
-﻿csmac.Coveralls - a coveralls.io coverage publisher for .Net
+﻿csmacnz.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
   csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]
@@ -34,7 +34,7 @@ Commit Options:
     * If git is available in the current working directory, the settings will be loaded from git.
 
 
-What its for:
+What it's for:
  Reads your .Net code coverage output data and submits it to
  coveralls.io's service. This can be used by your build scripts
  or with a CI builder server.

--- a/src/csmacnz.Coveralls/Program.cs
+++ b/src/csmacnz.Coveralls/Program.cs
@@ -151,6 +151,10 @@ namespace csmacnz.Coveralls
                         ExitWithError(message);
                     }
                 }
+                else
+                {
+                    Console.WriteLine("Coverage data uploaded to coveralls.");
+                }
             }
         }
 

--- a/src/csmacnz.Coveralls/Program.cs
+++ b/src/csmacnz.Coveralls/Program.cs
@@ -118,6 +118,7 @@ namespace csmacnz.Coveralls
             var gitData = ResolveGitData(args);
 
             var serviceJobId = ResolveServiceJobId(args);
+            var pullRequestId = ResolvePullRequestId(args);
 
             string serviceName = args.IsProvided("--serviceName") ? args.OptServicename : "coveralls.net";
             var data = new CoverallData
@@ -125,6 +126,7 @@ namespace csmacnz.Coveralls
                 RepoToken = repoToken,
                 ServiceJobId = serviceJobId.ValueOr("0"),
                 ServiceName = serviceName,
+                PullRequestId = pullRequestId.ValueOr(null),
                 SourceFiles = files.ToArray(),
                 Git = gitData.ValueOrDefault()
             };
@@ -168,6 +170,14 @@ namespace csmacnz.Coveralls
             if (args.IsProvided("--jobId")) return args.OptJobid;
             var jobId = new EnvironmentVariables().GetEnvironmentVariable("APPVEYOR_JOB_ID");
             if (jobId.IsNotNullOrWhitespace()) return jobId;
+            return null;
+        }
+
+        private static Option<string> ResolvePullRequestId(MainArgs args)
+        {
+            if (args.IsProvided("--pullRequest")) return args.OptPullrequest;
+            var prId = new EnvironmentVariables().GetEnvironmentVariable("APPVEYOR_PULL_REQUEST_NUMBER");
+            if (prId.IsNotNullOrWhitespace()) return prId;
             return null;
         }
 

--- a/src/csmacnz.Coveralls/T4DocoptNet.cs
+++ b/src/csmacnz.Coveralls/T4DocoptNet.cs
@@ -6,7 +6,7 @@ namespace csmacnz.Coveralls
     // Generated class for Main.usage.txt
     public class MainArgs
     {
-        public const string Usage = @"csmac.Coveralls - a coveralls.io coverage publisher for .Net
+        public const string Usage = @"csmacnz.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
   csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]

--- a/src/csmacnz.Coveralls/T4DocoptNet.cs
+++ b/src/csmacnz.Coveralls/T4DocoptNet.cs
@@ -9,7 +9,7 @@ namespace csmacnz.Coveralls
         public const string Usage = @"csmacnz.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
-  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]
+  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--pullRequest <pullRequestId>] [--treatUploadErrorsAsWarnings]
   csmacnz.Coveralls --version
   csmacnz.Coveralls --help
 
@@ -33,6 +33,7 @@ Options:
  --commitMessage <commitMessage>          The git commit message for the coverage report.
  --jobId <jobId>                          The job Id to provide to coveralls.io. [default: 0]
  --serviceName <Name>                     The service-name for the coverage report. [default: coveralls.net]
+ --pullRequest [pullRequestId]            The github pull request id. Used for updating status on github PRs.
  -k, --treatUploadErrorsAsWarnings        Exit successfully if an upload error is encountered and this flag is set.
 
 Commit Options:
@@ -85,6 +86,7 @@ What its for:
 		public string OptCommitmessage { get { return _args["--commitMessage"].ToString(); } }
 		public string OptJobid { get { return _args["--jobId"].ToString(); } }
 		public string OptServicename { get { return _args["--serviceName"].ToString(); } }
+		public string OptPullrequest { get { return _args["--pullRequest"].ToString(); } }
 		public bool OptTreatuploaderrorsaswarnings { get { return _args["--treatUploadErrorsAsWarnings"].IsTrue; } }
 		public bool OptVersion { get { return _args["--version"].IsTrue; } }
 		public bool OptHelp { get { return _args["--help"].IsTrue; } }

--- a/src/csmacnz.Coveralls/T4DocoptNet.cs
+++ b/src/csmacnz.Coveralls/T4DocoptNet.cs
@@ -33,7 +33,7 @@ Options:
  --commitMessage <commitMessage>          The git commit message for the coverage report.
  --jobId <jobId>                          The job Id to provide to coveralls.io. [default: 0]
  --serviceName <Name>                     The service-name for the coverage report. [default: coveralls.net]
- --pullRequest [pullRequestId]            The github pull request id. Used for updating status on github PRs.
+ --pullRequest <pullRequestId>            The github pull request id. Used for updating status on github PRs.
  -k, --treatUploadErrorsAsWarnings        Exit successfully if an upload error is encountered and this flag is set.
 
 Commit Options:
@@ -43,7 +43,7 @@ Commit Options:
     * If git is available in the current working directory, the settings will be loaded from git.
 
 
-What its for:
+What it's for:
  Reads your .Net code coverage output data and submits it to
  coveralls.io's service. This can be used by your build scripts
  or with a CI builder server.";


### PR DESCRIPTION
Added support for coveralls pull request. PR number can either be specified on command line or picked up from appveyor.

Based on #39.

I have successfully set this up on a repo I'm working on. Please see https://coveralls.io/github/KentorIT/authservices for example, where the pull requests have status updates from coveralls. An example is KentorIT/authservices#360 where the green check mark on the last commit shows coverall and appveyor statuses.

I also fixed a couple of minor typos and added a status printout on successful upload. I found it hard to know if the upload had been run or not during build without it. Please let me know if you don't like those things and I'll drop them from the PR.

New PR against develop. Now I'm keeping my fingers crossed that the build works this time.