### PR TITLE
Added Visual Studio Coverage Export support

### DIFF
--- a/src/csmacnz.Coveralls/ExportCodeCoverageParser.cs
+++ b/src/csmacnz.Coveralls/ExportCodeCoverageParser.cs
@@ -1,0 +1,103 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace csmacnz.Coveralls
+{
+    public class ExportCodeCoverageParser
+    {
+        public List<FileCoverageData> GenerateSourceFiles(XDocument document)
+        {
+            var files = new List<FileCoverageData>();
+            if(document.Root != null)
+            {
+                var sourceFilesInfo = new Dictionary<string, string>();
+
+                foreach(var sourceFile in document.Root.Elements("SourceFileNames"))
+                {
+                    var id = sourceFile.Element("SourceFileID")?.Value;
+                    var fileName = sourceFile.Element("SourceFileName")?.Value;
+
+                    if(id != null && fileName != null)
+                    {
+                        sourceFilesInfo.Add(id, fileName);
+                    }
+                }
+
+                foreach(var module in document.Root.Elements("Module"))
+                {
+                    foreach(var sourceFileInfo in sourceFilesInfo)
+                    {
+                        var fileId = sourceFileInfo.Key;
+                        var fullPath = sourceFileInfo.Value;
+
+                        var coverageBuilder = new FileCoverageDataBuilder(fullPath);
+
+                        var namespaceTable = module.Element("NamespaceTable");
+                        if(namespaceTable == null)
+                        {
+                            continue;
+                        }
+
+                        foreach(var @class in namespaceTable.Elements("Class"))
+                        {
+                            foreach(var method in @class.Elements("Method"))
+                            {
+                                foreach(var lines in method.Elements("Lines"))
+                                {
+                                    var sourceFileId = lines.Element("SourceFileID")?.Value;
+
+                                    if(sourceFileId == null)
+                                    {
+                                        continue;
+                                    }
+
+                                    if(sourceFileId != fileId)
+                                    {
+                                        continue;
+                                    }
+
+                                    var sourceStartLineElement = lines.Element("LnStart");
+
+                                    if(sourceStartLineElement == null)
+                                    {
+                                        continue;
+                                    }
+
+                                    var sourceStartLine = int.Parse(sourceStartLineElement.Value);
+
+                                    var sourceEndLineElement = lines.Element("LnEnd");
+
+                                    if(sourceEndLineElement == null)
+                                    {
+                                        continue;
+                                    }
+
+                                    var sourceEndLine = int.Parse(sourceEndLineElement.Value);
+
+
+                                    var coveredElement = lines.Element("Coverage");
+
+                                    if(coveredElement == null)
+                                    {
+                                        continue;
+                                    }
+
+                                    // A value of 2 means completely covered
+                                    var covered = coveredElement.Value == "2";
+
+                                    for(int lineNumber = sourceStartLine; lineNumber <= sourceEndLine; lineNumber++)
+                                    {
+                                        coverageBuilder.RecordCoverage(lineNumber, covered ? 1 : 0);
+                                    }
+                                }
+                            }
+                        }
+                        files.Add(coverageBuilder.CreateFile());
+                    }
+                }
+            }
+            return files;
+        }
+    }
+}

--- a/src/csmacnz.Coveralls/Main.usage.txt
+++ b/src/csmacnz.Coveralls/Main.usage.txt
@@ -1,7 +1,7 @@
 ﻿csmac.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
-  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]
+  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov | --exportcodecoverage) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]
   csmacnz.Coveralls --version
   csmacnz.Coveralls --help
 
@@ -15,6 +15,7 @@ Options:
  --basePath <path>                        When useRelativePaths and a basePath is provided, this path is used instead of the current working directory.
  --opencover                              Reads input as OpenCover data.
  --dynamiccodecoverage                    Reads input as the CodeCoverage.exe xml format.
+ --exportcodecoverage					  Reads input as the Visual Studio Coverage Export xml format
  --monocov                                Reads input as monocov results folder.
  --repoToken <repoToken>                  The coveralls.io repository token.
  --repoTokenVariable <repoTokenVariable>  The Environment Variable name where the coveralls.io repository token is available. [default: COVERALLS_REPO_TOKEN]

--- a/src/csmacnz.Coveralls/Program.cs
+++ b/src/csmacnz.Coveralls/Program.cs
@@ -79,6 +79,18 @@ namespace csmacnz.Coveralls
 
                     coverageData = new DynamicCodeCoverageParser().GenerateSourceFiles(document);
                 }
+                else if(args.IsProvided("--exportcodecoverage") && args.OptExportcodecoverage)
+                {
+                    var fileName = args.OptInput;
+                    if (!File.Exists(fileName))
+                    {
+                        ExitWithError("Input file '" + fileName + "' cannot be found");
+                    }
+
+                    var document = XDocument.Load(fileName);
+
+                    coverageData = new ExportCodeCoverageParser().GenerateSourceFiles(document);
+                }
                 else
                 {
                     var fileName = args.OptInput;

--- a/src/csmacnz.Coveralls/T4DocoptNet.cs
+++ b/src/csmacnz.Coveralls/T4DocoptNet.cs
@@ -9,7 +9,7 @@ namespace csmacnz.Coveralls
         public const string Usage = @"csmac.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
-  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]
+  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov | --exportcodecoverage) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--treatUploadErrorsAsWarnings]
   csmacnz.Coveralls --version
   csmacnz.Coveralls --help
 
@@ -23,6 +23,7 @@ Options:
  --basePath <path>                        When useRelativePaths and a basePath is provided, this path is used instead of the current working directory.
  --opencover                              Reads input as OpenCover data.
  --dynamiccodecoverage                    Reads input as the CodeCoverage.exe xml format.
+ --exportcodecoverage					  Reads input as the Visual Studio Coverage Export xml format
  --monocov                                Reads input as monocov results folder.
  --repoToken <repoToken>                  The coveralls.io repository token.
  --repoTokenVariable <repoTokenVariable>  The Environment Variable name where the coveralls.io repository token is available. [default: COVERALLS_REPO_TOKEN]
@@ -70,7 +71,8 @@ What its for:
 
 		public bool OptOpencover { get { return _args["--opencover"].IsTrue; } }
 		public bool OptDynamiccodecoverage { get { return _args["--dynamiccodecoverage"].IsTrue; } }
-		public bool OptMonocov { get { return _args["--monocov"].IsTrue; } }
+        public bool OptExportcodecoverage { get { return _args["--exportcodecoverage"].IsTrue; } }
+        public bool OptMonocov { get { return _args["--monocov"].IsTrue; } }
 		public string OptInput { get { return _args["--input"].ToString(); } }
 		public string OptRepotoken { get { return _args["--repoToken"].ToString(); } }
 		public string OptRepotokenvariable { get { return _args["--repoTokenVariable"].ToString(); } }

--- a/src/csmacnz.Coveralls/csmacnz.Coveralls.csproj
+++ b/src/csmacnz.Coveralls/csmacnz.Coveralls.csproj
@@ -77,6 +77,7 @@
     <Compile Include="CoverageFileBuilder.cs" />
     <Compile Include="CoverallData.cs" />
     <Compile Include="CoverallsService.cs" />
+    <Compile Include="ExportCodeCoverageParser.cs" />
     <Compile Include="EnvironmentVariables.cs" />
     <Compile Include="Crypto.cs" />
     <Compile Include="FileCoverageData.cs" />


### PR DESCRIPTION
The ExportCodeCoverageParser should handle coveragexml files exported by visual studio or the CoverageDs.ExportXml() call.