### PR TITLE
Added command line parameter "serviceNumber".

### DIFF
--- a/src/csmacnz.Coveralls/CoverallData.cs
+++ b/src/csmacnz.Coveralls/CoverallData.cs
@@ -13,6 +13,9 @@ namespace csmacnz.Coveralls
         [JsonProperty("service_name")]
         public string ServiceName { get; set; }
 
+        [JsonProperty("service_number")]
+        public string ServiceNumber { get; set; }
+
         [JsonProperty("service_pull_request", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string PullRequestId { get; set; }
 

--- a/src/csmacnz.Coveralls/Program.cs
+++ b/src/csmacnz.Coveralls/Program.cs
@@ -132,11 +132,14 @@ namespace csmacnz.Coveralls
             var pullRequestId = ResolvePullRequestId(args);
 
             string serviceName = args.IsProvided("--serviceName") ? args.OptServicename : "coveralls.net";
+            string serviceNumber = args.IsProvided("--serviceNumber") ? args.OptServicenumber : "";
+
             var data = new CoverallData
             {
                 RepoToken = repoToken,
                 ServiceJobId = serviceJobId.ValueOr("0"),
                 ServiceName = serviceName,
+                ServiceNumber = serviceNumber,
                 PullRequestId = pullRequestId.ValueOr(null),
                 SourceFiles = files.ToArray(),
                 Git = gitData.ValueOrDefault()

--- a/src/csmacnz.Coveralls/T4DocoptNet.cs
+++ b/src/csmacnz.Coveralls/T4DocoptNet.cs
@@ -9,7 +9,7 @@ namespace csmacnz.Coveralls
         public const string Usage = @"csmacnz.Coveralls - a coveralls.io coverage publisher for .Net
 
 Usage:
-  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov | --exportcodecoverage) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--pullRequest <pullRequestId>] [--treatUploadErrorsAsWarnings]
+  csmacnz.Coveralls (--opencover | --dynamiccodecoverage | --monocov | --exportcodecoverage) -i ./opencovertests.xml (--repoToken <repoToken> | [--repoTokenVariable <repoTokenVariable>]) [-o ./opencovertests.json] [--dryrun] [--useRelativePaths [--basePath <path>] ] [--commitId <commitId> --commitBranch <commitBranch> [--commitAuthor <commitAuthor> --commitEmail <commitEmail> --commitMessage <commitMessage>] ] [--jobId <jobId>] [--serviceName <Name>] [--serviceNumber <Number>] [--pullRequest <pullRequestId>] [--treatUploadErrorsAsWarnings]
   csmacnz.Coveralls --version
   csmacnz.Coveralls --help
 
@@ -34,6 +34,7 @@ Options:
  --commitMessage <commitMessage>          The git commit message for the coverage report.
  --jobId <jobId>                          The job Id to provide to coveralls.io. [default: 0]
  --serviceName <Name>                     The service-name for the coverage report. [default: coveralls.net]
+ --serviceNumber <Number>                 The service-number for the coverage report.
  --pullRequest <pullRequestId>            The github pull request id. Used for updating status on github PRs.
  -k, --treatUploadErrorsAsWarnings        Exit successfully if an upload error is encountered and this flag is set.
 
@@ -88,6 +89,7 @@ What it's for:
         public string OptCommitmessage { get { return _args["--commitMessage"].ToString(); } }
         public string OptJobid { get { return _args["--jobId"].ToString(); } }
         public string OptServicename { get { return _args["--serviceName"].ToString(); } }
+        public string OptServicenumber { get { return _args["--serviceNumber"].ToString(); } }
         public string OptPullrequest { get { return _args["--pullRequest"].ToString(); } }
         public bool OptTreatuploaderrorsaswarnings { get { return _args["--treatUploadErrorsAsWarnings"].IsTrue; } }
         public bool OptVersion { get { return _args["--version"].IsTrue; } }


### PR DESCRIPTION
This is treated as the build-number. (see: https://coveralls.zendesk.com/hc/en-us/articles/201350799-API-Reference)
I tested it with appveyor with the following call:
%coverallsconsoleexe%  --opencover -i ..\coverageresults.xml --serviceNumber %APPVEYOR_BUILD_NUMBER%

Best regards,
Nils