### PR TITLE
Remove quote from boundary header. Fixes #110

### DIFF
--- a/src/csmacnz.Coveralls/Adapters/CoverallsService.cs
+++ b/src/csmacnz.Coveralls/Adapters/CoverallsService.cs
@@ -52,6 +52,12 @@ public class CoverallsService : ICoverallsService
             { stringContent, "json_file", "coverage.json" }
         };
 
+        var boundary = formData.Headers.ContentType?.Parameters.FirstOrDefault(o => o.Name == "boundary");
+        if (boundary != null)
+        {
+            boundary.Value = boundary.Value?.Replace("\"", string.Empty);
+        }
+
         var response = client.PostAsync(new Uri(serverUrl, JobsUri), formData).Result;
 
         if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
It looks like Nginx doesn't like boundary header with quotes and returns 400. I guess that coveralls servers didn't have any issues with it but after they migrated to Cloudflare such requests are returning an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/csmacnz/coveralls.net/111)
<!-- Reviewable:end -->
